### PR TITLE
Do not jump back to 0 during a jump

### DIFF
--- a/envs/mnist.py
+++ b/envs/mnist.py
@@ -134,11 +134,12 @@ class MNIST(Environment):
         if 'size' in self.action_sizes:
             self.b.brushinfo.set_base_value('radius_logarithmic', size)
 
-        if (self.s_x is None and self.s_y is None) or \
-                ('jump' in self.action_sizes and jump):
+        if (self.s_x is None and self.s_y is None):
             # when self._step == 0
+            pressure = 0
             self.s_x, self.s_y = 0, 0
-            # when jump
+            self._stroke_to(self.s_x, self.s_y, pressure)
+        elif 'jump' in self.action_sizes and jump:
             pressure = 0
             self._stroke_to(self.s_x, self.s_y, pressure)
         else:


### PR DESCRIPTION
Fixes a bug where a jump causes a visible line from the previous ending point to (0, 0)